### PR TITLE
Fix/#1 firefox icon misalignment

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -68,3 +68,21 @@
 	font-weight: bold;
 	font-size: 0.9em;
 }
+
+/*
+---------------------------------------------------------------
+	For Firefox
+---------------------------------------------------------------
+*/
+
+@supports (-moz-appearance: none) {
+	.material-symbols-rounded:lang(ja) {
+		transform: translateY(0.02em);
+	}
+	.material-symbols-rounded:lang(zh-CN) {
+		transform: translateY(0.06em);
+	}
+	.material-symbols-rounded:lang(zh-TW) {
+		transform: translateY(0.09em);
+	}
+}


### PR DESCRIPTION
## Purpose
Fixed an issue in Firefox where icons appeared vertically misaligned when the extension’s language was set to Japanese, Simplified Chinese, or Traditional Chinese.

## Changes
- Added CSS styles to adjust the vertical position of icons specifically for Firefox.

## Testing
1. Open the extension’s options page or tutorial page in Firefox.  
2. Verify that the icons are no longer vertically misaligned.  

Closes #1
