### PR TITLE
Fix history headers not removed

### DIFF
--- a/js/history.js
+++ b/js/history.js
@@ -77,8 +77,17 @@ async function onDeleteHistoryButtonClick(event) {
 		const historyItemElement = document.querySelector(`.bili2vrc-history-item[data-bili2vrc-history-id="${historyID}"]`);
 		historyItemElement.classList.add('bili2vrc-deleting');
 		setTimeout(async () => {
+
+			/* Remove history item */
 			historyItemElement.remove();
-			await setNoHistoryMessage();
+
+			/* Save the current scroll position, reload the page,
+			   and restore the scroll position */
+			const scrollX = window.scrollX;
+			const scrollY = window.scrollY;
+			await setHistoryHTMLContent();
+			window.scrollTo(scrollX, scrollY);
+
 		}, 200);
 
 		/* Show history deleted popup */
@@ -102,6 +111,7 @@ async function setHistoryHTMLContent() {
 
 	/* Get history list container element */
 	const historyListElement = document.getElementById('history-list');
+	historyListElement.replaceChildren();
 
 	/** @type {Array.<Object.<string, *>>} Get parsing history */
 	const history = await loadFromStorage(storageKeys.HISTORY);

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
 	"icons": {
 		"256": "icons/ChromeIcon_256x256.png"
 	},
+	"host_permissions": [
+		"https://api.bilibili.com/*"
+	],
 	"permissions": [
 		"storage",
 		"tabs",
@@ -100,16 +103,6 @@
 		}
 	],
 	"background": {
-		"scripts": [
-			"js/utils/common-utils.js",
-			"js/utils/history-utils.js",
-			"js/utils/tutorial-utils.js",
-			"js/background.js"
-		]
-	},
-	"browser_specific_settings": {
-		"gecko": {
-			"id": "bili2vrc@example.com"
-		}
+		"service_worker": "js/background.js"
 	}
 }


### PR DESCRIPTION
## Purpose
Fixed an issue where section headers such as "Today" or "Yesterday" were not removed even when all history entries in the section were deleted.

## Changes
- Added a process to refresh the page content after deleting history entries.

## Testing
1. Open the video conversion history page.
2. Delete a history entry.
3. Verify that if a section becomes empty, its header is also removed.

Closes #2